### PR TITLE
Adding RSS feed file

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,23 @@
+---
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <title>Karen Cranston</title>
+    <link>{{site.url}}</link>
+    <description>When not sitting a desk, I am often found riding ponies.</description>
+    <copyright>Copyright (c) {{site.author}}.</copyright>
+    <lastBuildDate>{{site.time | date: "%a, %d %b %Y %H:%M:%S %Z"}}</lastBuildDate>
+    <generator>Jekyll</generator>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    {% for post in site.posts limit:20 %}
+      <item>
+        <title>{{post.title}}</title>
+        <author>{{site.email}} ({{site.author}})</author>
+        <link>{{site.url}}{{post.url}}</link>
+        <pubDate>{{post.date | date: "%a, %d %b %Y %H:%M:%S %Z"}}</pubDate>
+        <description>{{post.content|xml_escape}}</description>
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
Blog readers like Thunderbird need a feed.xml file so that they can keep track of new posts.
